### PR TITLE
Change default port to 9090

### DIFF
--- a/donkey_gym/envs/vae_env.py
+++ b/donkey_gym/envs/vae_env.py
@@ -63,7 +63,7 @@ class DonkeyVAEEnv(gym.Env):
             print("Missing DONKEY_SIM_PATH environment var. We assume the unity env is already started")
 
         # TCP port for communicating with simulation
-        port = int(os.environ.get('DONKEY_SIM_PORT', 9091))
+        port = int(os.environ.get('DONKEY_SIM_PORT', 9090))
 
         self.unity_process = None
         if exe_path is not None:


### PR DESCRIPTION
I had to change the port to 9090 to get the unity donkey simulator to connect.  Since the instructions don't specify to customize the DONKEY_SIM_PORT env variable, this should probably default to the port expected by the donkey simulator.