### PR TITLE
fix timestep_limit to max_episode_steps

### DIFF
--- a/donkey_gym/__init__.py
+++ b/donkey_gym/__init__.py
@@ -3,7 +3,7 @@ from gym.envs.registration import register
 register(
     id='DonkeyVae-v0',
     entry_point='donkey_gym.vae_env.vae_env:DonkeyVAEEnv',
-    timestep_limit=None,
+    max_episode_steps=None,
 )
 #
 # register(


### PR DESCRIPTION
```console
TypeError: __init__() got an unexpected keyword argument 'timestep_limit'
```

https://github.com/openai/gym/pull/1402

https://github.com/openai/gym/commit/85a5372a19c0f35db2410e586cc9a32c4d94bf1a
